### PR TITLE
changes for better event handling

### DIFF
--- a/example/page_code.js
+++ b/example/page_code.js
@@ -1,10 +1,10 @@
 (function () {
     // Cut the mustard
-    if ('querySelector' in window.parent.document &&
-        'addEventListener' in window.parent
+    if ('querySelector' in window.top.document &&
+        'addEventListener' in window.top
     ) {
         Ingestly.config({
-            endpoint: 'stat.example.com',
+            endpoint: 'stats.example.com',
             apiKey: '2ee204330a7b2701a6bf413473fcc486',
             eventName: 'ingestlyRecurringEvent',
             eventFrequency: 250,

--- a/src/events.js
+++ b/src/events.js
@@ -7,29 +7,30 @@ let managedEvents = {},
 export default class {
     constructor(config) {
         let event, timer;
-
-        try {
-            event = new CustomEvent(config.eventName);
-        } catch (e) {
-            event = window.parent.document.createEvent('CustomEvent');
-            event.initCustomEvent(config.eventName, false, false, {});
-        }
-
-        window.parent.requestAnimationFrame =
-            window.parent.requestAnimationFrame ||
-            window.parent.mozRequestAnimationFrame ||
-            window.parent.webkitRequestAnimationFrame;
-
-        (function recurringEvent() {
-            window.parent.requestAnimationFrame(recurringEvent);
-            if (timer) {
-                return false;
+        if (config.eventName && config.eventFrequency > 0) {
+            try {
+                event = new CustomEvent(config.eventName);
+            } catch (e) {
+                event = window.top.document.createEvent('CustomEvent');
+                event.initCustomEvent(config.eventName, false, false, {});
             }
-            timer = setTimeout(() => {
-                window.parent.dispatchEvent(event);
-                timer = null;
-            }, config.eventFrequency);
-        })();
+
+            window.top.requestAnimationFrame =
+                window.top.requestAnimationFrame ||
+                window.top.mozRequestAnimationFrame ||
+                window.top.webkitRequestAnimationFrame;
+
+            (function recurringEvent() {
+                window.top.requestAnimationFrame(recurringEvent);
+                if (timer) {
+                    return false;
+                }
+                timer = setTimeout(() => {
+                    window.top.dispatchEvent(event);
+                    timer = null;
+                }, config.eventFrequency);
+            })();
+        }
     }
 
     addListener(element, type, listener, capture) {

--- a/src/ingestly.js
+++ b/src/ingestly.js
@@ -45,6 +45,7 @@ export default class Ingestly {
             apiKey: config.apiKey,
             sdkVersion: sdkVersion,
             deviceId: idm.deviceId,
+            sessionId: idm.sessionId,
             rootId: idm.rootId,
             target: config.targetWindow,
         });
@@ -74,7 +75,7 @@ export default class Ingestly {
             this.dataModel[`rf${key}`] = parsedReferrer[key];
         }
 
-        if (config.eventName && config.eventFrequency && typeof events === 'undefined') {
+        if (typeof events === 'undefined') {
             events = new Events({
                 eventName: config.eventName,
                 eventFrequency: config.eventFrequency,
@@ -200,7 +201,7 @@ export default class Ingestly {
             window[targetWindow].document.body,
             'click',
             clickEvent => {
-                const targetAttribute = config.options.clicks.targetAttr || 'data-trackable';
+                const targetAttribute = config.options.clicks.targetAttr || false;
                 const trackableElement = utils.queryMatch(
                     'a, button, input, [role="button"]',
                     clickEvent.target,

--- a/src/utils.js
+++ b/src/utils.js
@@ -220,14 +220,14 @@ export default class {
         };
     }
 
-    queryMatch(selector, target, targetFlag = 'data-trackable') {
+    queryMatch(selector, target, targetFlag = false) {
         let element,
             category = 'button',
             p = [];
         if (target.nodeType === 3) {
             target = target.parentNode;
         }
-        while (target && target !== window.parent.document) {
+        while (target && target !== window.top.document) {
             let matches = (
                 target.matches ||
                 target.msMatchesSelector ||
@@ -235,9 +235,20 @@ export default class {
                     return false;
                 }
             ).bind(target);
-            if (target.hasAttribute(targetFlag)) {
-                p.unshift(target.getAttribute(targetFlag));
+            if (targetFlag) {
+                if (target.hasAttribute(targetFlag)) {
+                    p.unshift(target.getAttribute(targetFlag));
+                }
+            } else {
+                let elm = target.tagName.toLowerCase();
+                if (elm !== 'html' && elm !== 'body') {
+                    if (target.id) {
+                        elm += `.${target.id}`;
+                    }
+                    p.unshift(elm);
+                }
             }
+
             if (!element && matches(selector)) {
                 if (target.tagName.toLowerCase() === 'a') {
                     category = 'link';


### PR DESCRIPTION
- Added ability to disable the recurring event. The event is necessary for Scroll-Depth and Read-Through tracking however you can disable the event by setting `0` for `eventFrequency`  if you don't need to use it.
- trackClicks is now track all element if data-trackable is not set. It's hard to add `data-trackable` attribute for each element, but there is a strong demand to measure click events automatically. So, if you omit a setting `clicks.targetAttr`, `trackClicks()` works for elements without `data-trackable` attribute.