### PR TITLE
Add a lint rule to allow empty catch 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,10 @@
     "semi": [
       "warn",
       "always"
+    ],
+    "no-empty": [
+      "error",
+      { "allowEmptyCatch": true }
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ingestly-client-javascript",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.15.8",


### PR DESCRIPTION
Hi! thank you for providing such a useful tool. 

I got a couple of lint errors for [no-empty](https://eslint.org/docs/rules/no-empty) when running this library. I think these errors could be ignored, so I added a rule to allow empty catch.

```
ingestly-client-javascript/src/emitter.js
31:17  error  Empty block statement  no-empty
85:33  error  Empty block statement  no-empty
```